### PR TITLE
ci: add automated release workflow

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-forks/minio:ref:refs/heads/master
+claim_pattern:
+  workflow_ref: chainguard-forks/minio/.github/workflows/release.yml@refs/heads/master
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
               echo "need_release=no" >> $GITHUB_OUTPUT
             else
               echo "Tag $TAG exists, but no release is associated. Need a new release."
-              echo "need_release=yes" >> $GITHUB_OUTPUT
+              echo "need_release=yes" >> "$GITHUB_OUTPUT"
             fi
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,20 +3,21 @@ name: Create Release
 on:
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
 
       - name: Build
         run: go build ./...
@@ -24,11 +25,21 @@ jobs:
   release:
     needs: validate
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Set up Octo-STS
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: chainguard-forks/minio
+          identity: release
 
       - name: Generate release tag
         id: tag
@@ -37,13 +48,15 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           git tag "${{ steps.tag.outputs.tag }}"
           git push origin "${{ steps.tag.outputs.tag }}"
 
       - name: Create GitHub release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           gh release create "${{ steps.tag.outputs.tag }}" \
             --title "${{ steps.tag.outputs.tag }}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,22 +2,6 @@ name: Create Release
 
 on:
   workflow_dispatch:
-    inputs:
-      release_title:
-        description: "Release title"
-        required: true
-        default: "Bugfix Release"
-        type: choice
-        options:
-          - "Bugfix Release"
-          - "Security fix release"
-          - "Security and bug fix release"
-          - "Breaking Release"
-          - "Custom (specify below)"
-      custom_title:
-        description: "Custom release title (only used when 'Custom' is selected above)"
-        required: false
-        type: string
 
 permissions:
   contents: write
@@ -46,22 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Determine release title
-        id: title
-        env:
-          RELEASE_TITLE: ${{ inputs.release_title }}
-          CUSTOM_TITLE: ${{ inputs.custom_title }}
-        run: |
-          if [ "$RELEASE_TITLE" = "Custom (specify below)" ]; then
-            if [ -z "$CUSTOM_TITLE" ]; then
-              echo "::error::Custom title selected but no custom title provided"
-              exit 1
-            fi
-            echo "title=$CUSTOM_TITLE" >> "$GITHUB_OUTPUT"
-          else
-            echo "title=$RELEASE_TITLE" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Generate release tag
         id: tag
         run: |
@@ -76,9 +44,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TITLE: ${{ steps.title.outputs.title }}
         run: |
           gh release create "${{ steps.tag.outputs.tag }}" \
-            --title "$TITLE" \
-            --generate-notes \
-            --target master
+            --title "${{ steps.tag.outputs.tag }}" \
+            --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Create Release
 
 on:
+  schedule:
+    - cron: '0 0 * * 1' # every Monday at 00:00 UTC
   workflow_dispatch:
 
 permissions: {}
@@ -34,20 +36,68 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check if any changes since last release
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch --tags
+          TAG=$(git tag --points-at HEAD)
+          if [ -z "$TAG" ]; then
+            echo "No tag points at HEAD, checking if changes warrant a release."
+
+            # Get the last release tag
+            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+            if [ -n "$LAST_TAG" ]; then
+              echo "Last release tag: $LAST_TAG"
+
+              # Get all changed files since last tag
+              CHANGED_FILES=$(git diff --name-only "$LAST_TAG"..HEAD)
+
+              # Only release if changes include .go files, go.mod, or go.sum
+              RELEASE_WORTHY_CHANGES=$(echo "$CHANGED_FILES" | grep -E '(\.go$|^go\.mod$|^go\.sum$)' || true)
+
+              if [ -z "$RELEASE_WORTHY_CHANGES" ]; then
+                echo "No Go source files, go.mod, or go.sum changed since last release. Skipping release."
+                echo "need_release=no" >> $GITHUB_OUTPUT
+              else
+                echo "Found release-worthy changes since last release:"
+                echo "$RELEASE_WORTHY_CHANGES"
+                echo "need_release=yes" >> $GITHUB_OUTPUT
+              fi
+            else
+              echo "No previous tags found. Creating first release."
+              echo "need_release=yes" >> $GITHUB_OUTPUT
+            fi
+          else
+            RELEASE=$(gh release view "$TAG" --json tagName --jq '.tagName' || echo "none")
+            if [ "$RELEASE" == "$TAG" ]; then
+              echo "A release exists for tag $TAG, which has the latest changes, so no need for a new tag or release."
+              echo "need_release=no" >> $GITHUB_OUTPUT
+            else
+              echo "Tag $TAG exists, but no release is associated. Need a new release."
+              echo "need_release=yes" >> $GITHUB_OUTPUT
+            fi
+          fi
+
       - name: Set up Octo-STS
         uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        if: steps.check.outputs.need_release == 'yes'
         id: octo-sts
         with:
           scope: chainguard-forks/minio
           identity: release
 
       - name: Generate release tag
+        if: steps.check.outputs.need_release == 'yes'
         id: tag
         run: |
           TAG="RELEASE.$(date -u '+%Y-%m-%dT%H-%M-%SZ')"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create tag
+        if: steps.check.outputs.need_release == 'yes'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
@@ -55,6 +105,7 @@ jobs:
           git push origin "${{ steps.tag.outputs.tag }}"
 
       - name: Create GitHub release
+        if: steps.check.outputs.need_release == 'yes'
         env:
           GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.26.x
+          go-version: "1.26" 
+          cache: "false"
+          check-latest: "true"
 
       - name: Build
         run: go build ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Octo-STS
+        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
+        id: octo-sts
+        with:
+          scope: chainguard-forks/minio
+          identity: release
+
       - name: Check if any changes since last release
         id: check
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
         run: |
           git fetch --tags
           TAG=$(git tag --points-at HEAD)
@@ -82,14 +89,6 @@ jobs:
               echo "need_release=yes" >> "$GITHUB_OUTPUT"
             fi
           fi
-
-      - name: Set up Octo-STS
-        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
-        if: steps.check.outputs.need_release == 'yes'
-        id: octo-sts
-        with:
-          scope: chainguard-forks/minio
-          identity: release
 
       - name: Generate release tag
         if: steps.check.outputs.need_release == 'yes'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_title:
+        description: "Release title"
+        required: true
+        default: "Bugfix Release"
+        type: choice
+        options:
+          - "Bugfix Release"
+          - "Security fix release"
+          - "Security and bug fix release"
+          - "Breaking Release"
+          - "Custom (specify below)"
+      custom_title:
+        description: "Custom release title (only used when 'Custom' is selected above)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24.x
+
+      - name: Build
+        run: go build ./...
+
+  release:
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine release title
+        id: title
+        env:
+          RELEASE_TITLE: ${{ inputs.release_title }}
+          CUSTOM_TITLE: ${{ inputs.custom_title }}
+        run: |
+          if [ "$RELEASE_TITLE" = "Custom (specify below)" ]; then
+            if [ -z "$CUSTOM_TITLE" ]; then
+              echo "::error::Custom title selected but no custom title provided"
+              exit 1
+            fi
+            echo "title=$CUSTOM_TITLE" >> "$GITHUB_OUTPUT"
+          else
+            echo "title=$RELEASE_TITLE" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release tag
+        id: tag
+        run: |
+          TAG="RELEASE.$(date -u '+%Y-%m-%dT%H-%M-%SZ')"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        run: |
+          git tag "${{ steps.tag.outputs.tag }}"
+          git push origin "${{ steps.tag.outputs.tag }}"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: ${{ steps.title.outputs.title }}
+        run: |
+          gh release create "${{ steps.tag.outputs.tag }}" \
+            --title "$TITLE" \
+            --generate-notes \
+            --target master


### PR DESCRIPTION
Adds a `workflow_dispatch` action + automation for creating releases following upstream's `RELEASE.YYYY-MM-DDThh-mm-ssZ` tag format (see here https://github.com/minio/minio/releases). 

Includes a CI build validation gate, custom release title support, and is restricted to repo collaborators with write access.

