### PR TITLE
fix(ci): remove separate tag step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,14 +97,6 @@ jobs:
           TAG="RELEASE.$(date -u '+%Y-%m-%dT%H-%M-%SZ')"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-      - name: Create tag
-        if: steps.check.outputs.need_release == 'yes'
-        env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
-        run: |
-          git tag "${{ steps.tag.outputs.tag }}"
-          git push origin "${{ steps.tag.outputs.tag }}"
-
       - name: Create GitHub release
         if: steps.check.outputs.need_release == 'yes'
         env:


### PR DESCRIPTION
Let `gh release create` handle tag creation via the GitHub API using the Octo-STS token, instead of using `git push` which fails because the checkout action's HTTP credentials only have read access.