### PR TITLE
fix: guard SSE replication headers against injection (CVE-2026-34204)

### DIFF
--- a/cmd/handler-utils.go
+++ b/cmd/handler-utils.go
@@ -203,12 +203,21 @@ func extractMetadataFromMime(ctx context.Context, v textproto.MIMEHeader, m map[
 		nv[http.CanonicalHeaderKey(k)] = kv
 	}
 
+	// Guard: SSE replication headers must only be accepted from genuine
+	// replication requests. A regular client supplying these headers could
+	// inject fake sealed key material and bypass SSE verification
+	// (CVE-2026-34204).
+	isReplicationReq := len(nv[http.CanonicalHeaderKey(xhttp.MinIOSourceReplicationRequest)]) > 0
+
 	// Save all supported headers.
 	for _, supportedHeader := range supportedHeaders {
 		value, ok := nv[http.CanonicalHeaderKey(supportedHeader)]
 		if ok {
-			if v, ok := replicationToInternalHeaders[supportedHeader]; ok {
-				m[v] = strings.Join(value, ",")
+			if internalHeader, ok := replicationToInternalHeaders[supportedHeader]; ok {
+				if !isReplicationReq {
+					continue
+				}
+				m[internalHeader] = strings.Join(value, ",")
 			} else {
 				m[supportedHeader] = strings.Join(value, ",")
 			}


### PR DESCRIPTION
## Summary

`extractMetadataFromMime()` in `cmd/handler-utils.go` accepts any header listed in `supportedHeaders`, which includes the SSE replication headers (`X-Minio-Replication-Server-Side-Encryption-Sealed-Key`, `-Seal-Algorithm`, `-Iv`, `X-Minio-Replication-Encrypted-Multipart`, etc.). These get stored as internal object metadata via `replicationToInternalHeaders`.

A regular client can include these headers in a PUT request, injecting fake sealed key material into object metadata. This can cause the server to treat an unencrypted object as SSE-encrypted, or to use attacker-controlled key material — bypassing SSE verification.

## Fix

Add a replication request guard at the top of the `supportedHeaders` loop in `extractMetadataFromMime()`. Headers that map through `replicationToInternalHeaders` are only accepted when the request carries `X-Minio-Source-Replication-Request`, which is set exclusively by MinIO's internal replication system.

```go
isReplicationReq := len(nv[http.CanonicalHeaderKey(xhttp.MinIOSourceReplicationRequest)]) > 0
```

Non-replication requests that supply these headers will have them silently dropped.

## Notes

- This is a companion fix to PR #18 (CVE-2026-33419, LDAP brute-force)
- No API changes; no impact on legitimate replication flows
- Fixes only apply to the EmeritOSS fork — the upstream commercial MinIO patch is not available in open source

/cc @sergiodj for review