### PR TITLE
fix: require signature verification for query-string creds in unsigned-trailer uploads (CVE-2026-41145)

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -1896,7 +1896,12 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		}
 	case authTypeStreamingUnsignedTrailer:
 		// Initialize stream chunked reader with optional trailers.
-		rd, s3Err = newUnsignedV4ChunkedReader(r, true, r.Header.Get(xhttp.Authorization) != "")
+		// Require signature verification whenever credentials are supplied via
+		// either the Authorization header or the X-Amz-Credential query
+		// parameter; otherwise an attacker could pass credentials through the
+		// query string and bypass signing entirely (CVE-2026-41145).
+		hasCreds := r.Header.Get(xhttp.Authorization) != "" || r.Form.Get(xhttp.AmzCredential) != ""
+		rd, s3Err = newUnsignedV4ChunkedReader(r, true, hasCreds)
 		if s3Err != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
 			return

--- a/cmd/object-multipart-handlers.go
+++ b/cmd/object-multipart-handlers.go
@@ -686,7 +686,12 @@ func (api objectAPIHandlers) PutObjectPartHandler(w http.ResponseWriter, r *http
 		}
 	case authTypeStreamingUnsignedTrailer:
 		// Initialize stream signature verifier.
-		reader, s3Error = newUnsignedV4ChunkedReader(r, true, r.Header.Get(xhttp.Authorization) != "")
+		// Require signature verification whenever credentials are supplied via
+		// either the Authorization header or the X-Amz-Credential query
+		// parameter; otherwise an attacker could pass credentials through the
+		// query string and bypass signing entirely (CVE-2026-41145).
+		hasCreds := r.Header.Get(xhttp.Authorization) != "" || r.Form.Get(xhttp.AmzCredential) != ""
+		reader, s3Error = newUnsignedV4ChunkedReader(r, true, hasCreds)
 		if s3Error != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL)
 			return

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -128,6 +128,7 @@ func runAllTests(suite *TestSuiteCommon, c *check) {
 	suite.TestBucketSQSNotificationWebHook(c)
 	suite.TestBucketSQSNotificationAMQP(c)
 	suite.TestUnsignedCVE(c)
+	suite.TestCVE202641145(c)
 	suite.TearDownSuite(c)
 }
 
@@ -407,6 +408,81 @@ func (s *TestSuiteCommon) TestUnsignedCVE(c *check) {
 
 	// assert the http response status code.
 	c.Assert(response.StatusCode, http.StatusBadRequest)
+}
+
+// TestCVE202641145 is a regression test for CVE-2026-41145: an authentication
+// bypass in the STREAMING-UNSIGNED-PAYLOAD-TRAILER code path.
+//
+// Before the fix, isPutActionAllowed accepted credentials supplied via the
+// X-Amz-Credential query parameter, but the signature gate in
+// newUnsignedV4ChunkedReader only checked for the Authorization *header*.
+// An attacker could therefore omit the Authorization header, supply credentials
+// in the query string, pass the IAM check, and have the body written without
+// any signature ever being verified.
+func (s *TestSuiteCommon) TestCVE202641145(c *check) {
+	c.Helper()
+
+	body := []byte("attack-payload")
+	bucketName := getRandomBucketName()
+
+	request, err := newTestSignedRequest(http.MethodPut, getMakeBucketURL(s.endPoint, bucketName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, nil)
+	response, err := s.client.Do(request)
+	c.Assert(err, nil)
+	c.Assert(response.StatusCode, http.StatusOK)
+
+	now := UTCNow()
+	region := globalSite.Region()
+
+	// --- Attack case: X-Amz-Credential in query string, no Authorization header.
+	//
+	// getRequestAuthType classifies this as authTypeStreamingUnsignedTrailer
+	// (the x-amz-content-sha256 header match fires before isRequestPresignedSignatureV4).
+	// isPutActionAllowed then authenticates the caller from the query string.
+	// Before the fix, hasCreds was false (header absent) so doesSignatureMatch
+	// was never called and the write went through unauthenticated.
+	credScope := s.accessKey + SlashSeparator + getScope(now, region)
+	attackURL := makeTestTargetURL(s.endPoint, bucketName, "attack-object", url.Values{
+		xhttp.AmzCredential: []string{credScope},
+		xhttp.AmzDate:       []string{now.Format(iso8601Format)},
+	})
+
+	attackReq, err := http.NewRequest(http.MethodPut, attackURL, nil)
+	c.Assert(err, nil)
+	attackReq.Body = io.NopCloser(bytes.NewReader(body))
+	attackReq.Header.Set("x-amz-content-sha256", unsignedPayloadTrailer)
+	attackReq.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(body)))
+	attackReq.Header.Set("Content-Encoding", "aws-chunked")
+	attackReq = signer.StreamingUnsignedV4(attackReq, "", int64(len(body)), now)
+	attackReq.Header.Del("Authorization")
+
+	response, err = s.client.Do(attackReq)
+	c.Assert(err, nil)
+	if response.StatusCode == http.StatusOK {
+		c.Fatal("CVE-2026-41145: unsigned-trailer PUT with query-string-only credentials was accepted; signature verification bypass is present")
+	}
+
+	// --- Legitimate case: same streaming content type with a proper Authorization header.
+	//
+	// Ensures the fix does not break correctly signed STREAMING-UNSIGNED-PAYLOAD-TRAILER uploads.
+	// We manually encode the aws-chunked body to avoid TransferEncoding interference from
+	// signer.StreamingUnsignedV4, which sets req.TransferEncoding and causes Go's HTTP client
+	// to double-encode the body.
+	chunkedBody := fmt.Sprintf("%x\r\n%s\r\n0\r\n", len(body), body)
+	legitReq, err := http.NewRequest(http.MethodPut, getPutObjectURL(s.endPoint, bucketName, "legit-object"), nil)
+	c.Assert(err, nil)
+	legitReq.Body = io.NopCloser(strings.NewReader(chunkedBody))
+	legitReq.ContentLength = int64(len(chunkedBody))
+	legitReq.Header.Set("x-amz-content-sha256", unsignedPayloadTrailer)
+	legitReq.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(body)))
+	legitReq.Header.Set("Content-Encoding", "aws-chunked")
+	err = signRequestV4(legitReq, s.accessKey, s.secretKey)
+	c.Assert(err, nil)
+
+	response, err = s.client.Do(legitReq)
+	c.Assert(err, nil)
+	c.Assert(response.StatusCode, http.StatusOK)
 }
 
 func (s *TestSuiteCommon) TestBucketSQSNotificationAMQP(c *check) {


### PR DESCRIPTION
## Summary

Patches **CVE-2026-41145** ([GHSA-hv4r-mvr4-25vw](https://github.com/minio/minio/security/advisories/GHSA-hv4r-mvr4-25vw)) — an authentication bypass in the `STREAMING-UNSIGNED-PAYLOAD-TRAILER` code path that lets anyone holding a valid access key (e.g. the default `minioadmin`) write arbitrary objects without supplying a valid signature.

## The bug

`PutObjectHandler` (`cmd/object-handlers.go`) and `PutObjectPartHandler` (`cmd/object-multipart-handlers.go`) gated signature verification only on the presence of the `Authorization` header:

```go
newUnsignedV4ChunkedReader(r, true, r.Header.Get(xhttp.Authorization) != "")
```

`isPutActionAllowed`, however, accepts credentials extracted from either the `Authorization` header or the `X-Amz-Credential` query parameter (via `getReqAccessKeyV4`). An attacker omits `Authorization` and supplies credentials in the query string. `isPutActionAllowed` happily authenticates them, and the streaming reader's signature gate evaluates to `false` — `doesSignatureMatch` is never called and the request is written under the impersonated identity with no signature ever verified.

This affects standard PUT, tables/warehouse bucket PUT, and multipart upload parts.

## The fix

Extend the gate so signature verification is required whenever credentials are supplied through *either* channel:

```go
hasCreds := r.Header.Get(xhttp.Authorization) != "" || r.Form.Get(xhttp.AmzCredential) != ""
rd, s3Err = newUnsignedV4ChunkedReader(r, true, hasCreds)
```

`doesSignatureMatch` only inspects the `Authorization` header, so requests carrying credentials only in the query string will fail signature verification and be rejected — which is the correct behaviour: `STREAMING-UNSIGNED-PAYLOAD-TRAILER` is not a valid combination with presigned-URL credentials. Genuinely anonymous requests (no creds anywhere) keep `signature=false` and are still subject only to the existing bucket-policy check, so the change does not break unauthenticated public-bucket writes that were previously allowed.

## Scope assessment

Within EmeritOSS best-effort source-CVE policy: small, contained, no API changes, no refactor. Same shape as PR #18 and PR #23.

## Test plan

- [ ] CI must pass on this PR (full upstream test matrix runs against streaming auth paths)
- [ ] Manual: attempt an unsigned-trailer PUT with `X-Amz-Credential=minioadmin/…` in query string and no `Authorization` header — should now be rejected
- [ ] Manual: a normal unsigned-trailer PUT with valid `Authorization` header continues to work
- [ ] Manual: an anonymous PUT against a bucket with a permissive policy still works (no creds anywhere)