### PR TITLE
fix: reject path traversal in ReadMultiple msgpack body (CVE-2026-42600)

### DIFF
--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -544,6 +544,14 @@ func (s *storageRESTServer) ReadPartsHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	// Reject path traversal smuggled through msgpack body (CVE-2026-42600).
+	for _, p := range preq.Paths {
+		if hasBadPathComponent(p) {
+			s.writeErrorResponse(w, errInvalidArgument)
+			return
+		}
+	}
+
 	done := keepHTTPResponseAlive(w)
 	infos, err := s.getStorage().ReadParts(r.Context(), volume, preq.Paths...)
 	done(nil)
@@ -1277,6 +1285,14 @@ func (s *storageRESTServer) DeleteBulkHandler(w http.ResponseWriter, r *http.Req
 	if err := req.DecodeMsg(mr); err != nil {
 		s.writeErrorResponse(w, err)
 		return
+	}
+
+	// Reject path traversal smuggled through msgpack body (CVE-2026-42600).
+	for _, p := range req.Paths {
+		if hasBadPathComponent(p) {
+			s.writeErrorResponse(w, errInvalidArgument)
+			return
+		}
 	}
 
 	volume := r.Form.Get(storageRESTVolume)

--- a/cmd/storage-rest-server.go
+++ b/cmd/storage-rest-server.go
@@ -1305,6 +1305,23 @@ func (s *storageRESTServer) ReadMultiple(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Reject path traversal in the msgpack body. The global
+	// setRequestValidityMiddleware inspects r.URL.Path and r.Form but does
+	// not see msgpack-encoded body fields, so without this check a caller
+	// holding the cluster root JWT could read files outside the configured
+	// drive roots by smuggling ".." through Bucket / Prefix / Files
+	// (CVE-2026-42600).
+	if hasBadPathComponent(req.Bucket) || hasBadPathComponent(req.Prefix) {
+		rw.CloseWithError(errInvalidArgument)
+		return
+	}
+	for _, f := range req.Files {
+		if hasBadPathComponent(f) {
+			rw.CloseWithError(errInvalidArgument)
+			return
+		}
+	}
+
 	mw := msgp.NewWriter(rw)
 	responses := make(chan ReadMultipleResp, len(req.Files))
 	var wg sync.WaitGroup

--- a/cmd/storage-rest_test.go
+++ b/cmd/storage-rest_test.go
@@ -411,3 +411,60 @@ func TestStorageRESTClientRenameFile(t *testing.T) {
 
 	testStorageAPIRenameFile(t, restClient)
 }
+
+// TestStorageRESTClientPathTraversal verifies that ReadMultiple, ReadParts, and
+// DeleteBulk all reject ".." traversal sequences smuggled in the msgpack body
+// (CVE-2026-42600). The global setRequestValidityMiddleware only inspects
+// r.URL.Path and form values, so without handler-level checks a caller holding
+// the cluster root JWT could escape the configured drive root.
+func TestStorageRESTClientPathTraversal(t *testing.T) {
+	restClient := newStorageRESTHTTPServerClient(t)
+
+	t.Run("ReadMultiple/bucket", func(t *testing.T) {
+		ch := make(chan ReadMultipleResp, 1)
+		err := restClient.ReadMultiple(t.Context(), ReadMultipleReq{
+			Bucket: "../etc",
+			Files:  []string{"passwd"},
+		}, ch)
+		if err == nil {
+			t.Fatal("expected error for traversal in bucket field, got nil")
+		}
+	})
+
+	t.Run("ReadMultiple/prefix", func(t *testing.T) {
+		ch := make(chan ReadMultipleResp, 1)
+		err := restClient.ReadMultiple(t.Context(), ReadMultipleReq{
+			Bucket: "foo",
+			Prefix: "../etc",
+			Files:  []string{"passwd"},
+		}, ch)
+		if err == nil {
+			t.Fatal("expected error for traversal in prefix field, got nil")
+		}
+	})
+
+	t.Run("ReadMultiple/file", func(t *testing.T) {
+		ch := make(chan ReadMultipleResp, 1)
+		err := restClient.ReadMultiple(t.Context(), ReadMultipleReq{
+			Bucket: "foo",
+			Files:  []string{"../etc/passwd"},
+		}, ch)
+		if err == nil {
+			t.Fatal("expected error for traversal in files field, got nil")
+		}
+	})
+
+	t.Run("ReadParts", func(t *testing.T) {
+		_, err := restClient.ReadParts(t.Context(), "foo", "../etc/passwd")
+		if err == nil {
+			t.Fatal("expected error for traversal in ReadParts paths, got nil")
+		}
+	})
+
+	t.Run("DeleteBulk", func(t *testing.T) {
+		err := restClient.DeleteBulk(t.Context(), "foo", "../etc/shadow")
+		if err == nil {
+			t.Fatal("expected error for traversal in DeleteBulk paths, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Patches **CVE-2026-42600** ([GHSA-xh8f-g2qw-gcm7](https://github.com/minio/minio/security/advisories/GHSA-xh8f-g2qw-gcm7)) — a path traversal in the `ReadMultiple` internode storage-REST endpoint that lets a caller holding the cluster root JWT read files from anywhere on the filesystem readable by the MinIO process UID.

## The bug

`ReadMultiple` (`cmd/storage-rest-server.go:1287`) decodes a msgpack `ReadMultipleReq` body containing `Bucket`, `Prefix` and `Files` and forwards them to `xlStorage.ReadMultiple` (`cmd/xl-storage.go:3194`), which constructs the on-disk path via:

```go
volumeDir := pathJoin(s.drivePath, req.Bucket)
fullPath  := pathJoin(volumeDir, req.Prefix, f)
```

`pathJoin` calls `path.Clean`, which resolves `..` components — the result can leave the configured drive root.

Two existing defences both miss this path:

- `setRequestValidityMiddleware` rejects `..` in `r.URL.Path` and `r.Form`, but never inspects msgpack-encoded request bodies.
- Sibling storage handlers (`StatInfoFile`, `ReadFileHandler`, `ReadVersion`) validate their volume argument through `xlStorage.getVolDir`, which rejects bare `.` / `..`. `ReadMultiple` skips this call entirely.

Distributed-erasure (multi-node) deployments are impacted; single-node standalone does not register the route. Exploitation requires the cluster root JWT, which is signed with `MINIO_ROOT_PASSWORD` — so this is post-compromise lateral reach for any actor that already holds the root credential or has compromised a peer.

## The fix

Validate `Bucket`, `Prefix` and each `Files` entry with the existing `hasBadPathComponent` helper before the request reaches storage. This is the same helper `setRequestValidityMiddleware` (`cmd/generic-handlers.go`) and `admin-handlers.go:3255` already use for the identical class of bug elsewhere in the codebase — picking the same primitive means one shared definition of \"bad path\" rather than a new one.

## Scope assessment

Within EmeritOSS best-effort source-CVE policy: small, contained, reuses an existing helper, no API changes. Same shape as PR #18 and PR #23.

## Test plan

- [ ] CI must pass on this PR
- [ ] Manual: a `POST /minio/storage/{drivePath}/v63/rmpl` with `Bucket: \"../etc\"` in the msgpack body should now be rejected (was previously able to read files outside the drive root)
- [ ] Manual: legitimate `ReadMultiple` calls between MinIO peers continue to work