### PR TITLE
fix: add timeouts to healing scripts to prevent CI hangs

### DIFF
--- a/.github/workflows/go-healing.yml
+++ b/.github/workflows/go-healing.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     name: Go ${{ matrix.go-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
     strategy:
       matrix:
         go-version: [1.25.x]

--- a/buildscripts/heal-inconsistent-versions.sh
+++ b/buildscripts/heal-inconsistent-versions.sh
@@ -31,7 +31,7 @@ function start_minio_4drive() {
 	C_PWD=${PWD}
 	if [ ! -x "$PWD/mc" ]; then
 		MC_BUILD_DIR="mc-$RANDOM"
-		if ! git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
+		if ! timeout 5m git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
 			echo "failed to download https://github.com/minio/mc"
 			purge "${MC_BUILD_DIR}"
 			exit 1

--- a/buildscripts/resolve-right-versions.sh
+++ b/buildscripts/resolve-right-versions.sh
@@ -24,7 +24,7 @@ function start_minio_5drive() {
 	export MINIO_CI_CD=1
 
 	MC_BUILD_DIR="mc-$RANDOM"
-	if ! git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
+	if ! timeout 5m git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
 		echo "failed to download https://github.com/minio/mc"
 		purge "${MC_BUILD_DIR}"
 		exit 1

--- a/buildscripts/rewrite-old-new.sh
+++ b/buildscripts/rewrite-old-new.sh
@@ -16,7 +16,7 @@ fi
 
 function download_old_release() {
 	if [ ! -f minio.RELEASE.2020-10-28T08-16-50Z ]; then
-		curl --silent --max-time 300 -O https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
+		curl --silent --max-time 300 -fL -o minio.RELEASE.2020-10-28T08-16-50Z https://dl.min.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
 		chmod a+x minio.RELEASE.2020-10-28T08-16-50Z
 	fi
 }

--- a/buildscripts/rewrite-old-new.sh
+++ b/buildscripts/rewrite-old-new.sh
@@ -16,7 +16,7 @@ fi
 
 function download_old_release() {
 	if [ ! -f minio.RELEASE.2020-10-28T08-16-50Z ]; then
-		curl --silent -O https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
+		curl --silent --max-time 300 -O https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2020-10-28T08-16-50Z
 		chmod a+x minio.RELEASE.2020-10-28T08-16-50Z
 	fi
 }
@@ -31,7 +31,7 @@ function verify_rewrite() {
 	export MINIO_CI_CD=1
 
 	MC_BUILD_DIR="mc-$RANDOM"
-	if ! git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
+	if ! timeout 5m git clone --quiet https://github.com/minio/mc "$MC_BUILD_DIR"; then
 		echo "failed to download https://github.com/minio/mc"
 		purge "${MC_BUILD_DIR}"
 		exit 1
@@ -46,7 +46,7 @@ function verify_rewrite() {
 	pid=$!
 	disown $pid
 
-	"${WORK_DIR}/mc" ready minio/
+	timeout 15m "${WORK_DIR}/mc" ready minio/
 
 	if ! ps -p ${pid} 1>&2 >/dev/null; then
 		echo "server1 log:"
@@ -79,7 +79,7 @@ function verify_rewrite() {
 	pid=$!
 	disown $pid
 
-	"${WORK_DIR}/mc" ready minio/
+	timeout 15m "${WORK_DIR}/mc" ready minio/
 
 	if ! ps -p ${pid} 1>&2 >/dev/null; then
 		echo "server1 log:"

--- a/buildscripts/verify-healing-empty-erasure-set.sh
+++ b/buildscripts/verify-healing-empty-erasure-set.sh
@@ -42,9 +42,19 @@ function start_minio_3_node() {
 	timeout 15m /tmp/mc ready myminio || fail
 
 	# Wait for all drives to be online and formatted
-	while [ $(/tmp/mc admin info --json myminio | jq '.info.servers[].drives[].state | select(. != "ok")' | wc -l) -gt 0 ]; do sleep 1; done
+	drive_wait=0
+	while [ $(/tmp/mc admin info --json myminio | jq '.info.servers[].drives[].state | select(. != "ok")' | wc -l) -gt 0 ]; do
+		sleep 1
+		drive_wait=$((drive_wait + 1))
+		if [ $drive_wait -ge 300 ]; then echo "Timed out waiting for drives to reach ok state" && fail; fi
+	done
 	# Wait for all drives to be healed
-	while [ $(/tmp/mc admin info --json myminio | jq '.info.servers[].drives[].healing | select(. != null) | select(. == true)' | wc -l) -gt 0 ]; do sleep 1; done
+	heal_wait=0
+	while [ $(/tmp/mc admin info --json myminio | jq '.info.servers[].drives[].healing | select(. != null) | select(. == true)' | wc -l) -gt 0 ]; do
+		sleep 1
+		heal_wait=$((heal_wait + 1))
+		if [ $heal_wait -ge 600 ]; then echo "Timed out waiting for healing to complete" && fail; fi
+	done
 
 	# Wait for Status: in MinIO output
 	while true; do
@@ -119,7 +129,7 @@ function __init__() {
 	echo '{"version": "3", "credential": {"accessKey": "minio", "secretKey": "minio123"}, "region": "us-east-1"}' >"$MINIO_CONFIG_DIR/config.json"
 
 	if [ ! -f /tmp/mc ]; then
-		wget --quiet -O /tmp/mc https://dl.minio.io/client/mc/release/linux-amd64/mc &&
+		wget --quiet --timeout=300 -O /tmp/mc https://dl.minio.io/client/mc/release/linux-amd64/mc &&
 			chmod +x /tmp/mc
 	fi
 }

--- a/buildscripts/verify-healing-with-root-disks.sh
+++ b/buildscripts/verify-healing-with-root-disks.sh
@@ -33,9 +33,12 @@ function start_minio() {
 
 	# Wait until all nodes return 403
 	for i in $(seq 1 4); do
+		srv_wait=0
 		while [ "$(curl -m 1 -s -o /dev/null -w "%{http_code}" http://localhost:$((start_port + i)))" -ne "403" ]; do
 			echo -n "."
 			sleep 1
+			srv_wait=$((srv_wait + 1))
+			if [ $srv_wait -ge 120 ]; then echo "Timed out waiting for server $i to start" && exit 1; fi
 		done
 	done
 
@@ -65,10 +68,13 @@ function main() {
 	# Unmount the disk, after the unmount the device id
 	# /tmp/xxx/mnt/disk4 will be the same as '/' and it
 	# will be detected as root disk
+	umount_retries=0
 	while [ "$u" != "0" ]; do
 		sudo umount ${WORK_DIR}/mnt/disk4/
 		u=$?
 		sleep 1
+		umount_retries=$((umount_retries + 1))
+		if [ $umount_retries -ge 30 ]; then echo "Timed out waiting for umount of disk4" && exit 1; fi
 	done
 
 	# Wait until MinIO self heal kicks in

--- a/buildscripts/verify-healing.sh
+++ b/buildscripts/verify-healing.sh
@@ -120,7 +120,7 @@ function __init__() {
 	echo '{"version": "3", "credential": {"accessKey": "minio", "secretKey": "minio123"}, "region": "us-east-1"}' >"$MINIO_CONFIG_DIR/config.json"
 
 	if [ ! -f /tmp/mc ]; then
-		wget --quiet -O /tmp/mc https://dl.minio.io/client/mc/release/linux-amd64/mc &&
+		wget --quiet --timeout=300 -O /tmp/mc https://dl.minio.io/client/mc/release/linux-amd64/mc &&
 			chmod +x /tmp/mc
 	fi
 }


### PR DESCRIPTION
## Summary

- Adds `--timeout=300` to `wget` calls downloading `mc` binary
- Wraps `git clone` calls with `timeout 5m` when building `mc` from source
- Adds `--max-time 300` to `curl` download of old MinIO release
- Wraps bare `mc ready` calls with `timeout 15m`
- Caps the unbounded `while` loops polling drive state (300s) and healing completion (600s)
- Caps the unbounded `while` loops waiting for `umount` (30 retries) and server 403 (120 retries)
- Adds `timeout-minutes: 90` to the `go-healing.yml` job

## Background

Every healing workflow run in this repo has either been cancelled by a follow-up push (via the concurrency cancel) or hit GitHub Actions' 6-hour default job timeout. None have ever completed. The root causes are multiple places where network operations and polling loops have no upper bound:

| File | Issue |
|------|-------|
| `verify-healing.sh` | `wget` with no `--timeout` |
| `verify-healing-empty-erasure-set.sh` | `wget` with no `--timeout`; two unbounded `while` loops polling drive/healing state |
| `verify-healing-with-root-disks.sh` | Unbounded `while` loop waiting for server 403; unbounded `while` loop retrying `umount` |
| `heal-inconsistent-versions.sh` | `git clone` with no timeout |
| `resolve-right-versions.sh` | `git clone` with no timeout |
| `rewrite-old-new.sh` | `git clone` + `curl` download + two bare `mc ready` calls, all without timeouts |
| `go-healing.yml` | No `timeout-minutes` set (GitHub default: 6 hours) |

## Test plan

- [ ] Healing workflow completes (or fails fast with an error) rather than hanging indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)