### PR TITLE
fix: update nginx image for CVE-2026-9256

### DIFF
--- a/.github/workflows/mint/minio-compress-encrypt.yaml
+++ b/.github/workflows/mint/minio-compress-encrypt.yaml
@@ -54,7 +54,7 @@ services:
       - cdata4-2:/cdata2
 
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: nginx
     volumes:
       - ./nginx-4-node.conf:/etc/nginx/nginx.conf:ro

--- a/.github/workflows/mint/minio-erasure.yaml
+++ b/.github/workflows/mint/minio-erasure.yaml
@@ -32,7 +32,7 @@ services:
       - edata1-4:/edata4
 
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: nginx
     volumes:
       - ./nginx-1-node.conf:/etc/nginx/nginx.conf:ro

--- a/.github/workflows/mint/minio-pools.yaml
+++ b/.github/workflows/mint/minio-pools.yaml
@@ -79,7 +79,7 @@ services:
       - pdata8-2:/pdata2
       
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: nginx
     volumes:
       - ./nginx-8-node.conf:/etc/nginx/nginx.conf:ro

--- a/.github/workflows/mint/minio-resiliency.yaml
+++ b/.github/workflows/mint/minio-resiliency.yaml
@@ -52,7 +52,7 @@ services:
       - rdata4-2:/rdata2
 
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: nginx
     volumes:
       - ./nginx-4-node.conf:/etc/nginx/nginx.conf:ro

--- a/.github/workflows/multipart/docker-compose-site1.yaml
+++ b/.github/workflows/multipart/docker-compose-site1.yaml
@@ -41,7 +41,7 @@ services:
       - site1-data4-2:/data2
 
   site1-nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: site1-nginx
     volumes:
       - ./nginx-site1.conf:/etc/nginx/nginx.conf:ro

--- a/.github/workflows/multipart/docker-compose-site2.yaml
+++ b/.github/workflows/multipart/docker-compose-site2.yaml
@@ -41,7 +41,7 @@ services:
       - site2-data4-2:/data2
 
   site2-nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: site2-nginx
     volumes:
       - ./nginx-site2.conf:/etc/nginx/nginx.conf:ro

--- a/buildscripts/upgrade-tests/compose.yml
+++ b/buildscripts/upgrade-tests/compose.yml
@@ -45,7 +45,7 @@ services:
       - data4-3:/data3
 
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     ports:

--- a/docs/orchestration/docker-compose/docker-compose.yaml
+++ b/docs/orchestration/docker-compose/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       - data4-2:/data2
 
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: nginx
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro

--- a/docs/resiliency/docker-compose.yaml
+++ b/docs/resiliency/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - data4-8:/data8
 
   nginx:
-    image: nginx:1.19.2-alpine
+    image: nginx:1.30.2-alpine
     hostname: nginx
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro


### PR DESCRIPTION
## Summary
- update checked-in NGINX compose images from `nginx:1.19.2-alpine` to `nginx:1.30.2-alpine`
- use the fixed NGINX stable line for CVE-2026-9256 / Poolslip

## Validation
- `rg -n "nginx:1\\.19\\.2-alpine" . --glob '!/.agent-shell/**'` returned no matches
- `git diff --check`
- `docker compose -f <file> config` for all 9 touched compose files