### PR TITLE
fix: enforce JWT alg/key-type binding in OIDC auth (CVE-2026-33322)

### DIFF
--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -174,12 +174,12 @@ func (r *Config) Validate(ctx context.Context, arn arn.ARN, token, accessToken, 
 	// ValidMethods, not a binding between the algorithm and the key type, so it
 	// does not stop this on its own.
 	//
-	// Mitigation: HMAC (symmetric) signing is only honoured when the IdP's
+	// Mitigation: HMAC (symmetric) signing is only honored when the IdP's
 	// discovery document advertises an HMAC id_token signing algorithm. For the
 	// common asymmetric deployments the HS* algorithms are removed from the set
 	// of accepted methods entirely, which prevents the ClientSecret from ever
 	// being used as a token verification key. We additionally bind the token's
-	// algorithm to the resolved key's type inside the keyfunc as defence in
+	// algorithm to the resolved key's type inside the keyfunc as defense in
 	// depth.
 	allowHMAC := providerAllowsHMAC(pCfg)
 

--- a/internal/config/identity/openid/jwt.go
+++ b/internal/config/identity/openid/jwt.go
@@ -132,15 +132,66 @@ const (
 	azpClaim = "azp"
 )
 
+// providerAllowsHMAC reports whether symmetric (HMAC, i.e. HS256/384/512)
+// id_token signing is permitted for the given provider.
+//
+// CVE-2026-33322 / GHSA-5cx5-wh4m-82fh: HMAC verification uses the ClientSecret
+// as the key. Permitting HMAC unconditionally enables a JWT algorithm-confusion
+// attack against the (overwhelmingly common) asymmetric deployments, where an
+// attacker who knows the ClientSecret can forge tokens. We therefore only allow
+// HMAC when the IdP's discovery document explicitly advertises an HMAC
+// id_token signing algorithm. If the discovery document does not list any
+// signing algorithms (HMAC nor asymmetric) we conservatively withhold HMAC,
+// since the secure default for OIDC is asymmetric signing.
+func providerAllowsHMAC(pCfg *providerCfg) bool {
+	for _, alg := range pCfg.DiscoveryDoc.IDTokenSigningAlgValuesSupported {
+		switch alg {
+		case "HS256", "HS384", "HS512":
+			return true
+		}
+	}
+	return false
+}
+
 // Validate - validates the id_token.
 func (r *Config) Validate(ctx context.Context, arn arn.ARN, token, accessToken, dsecs string, claims map[string]any) error {
+	pCfg, ok := r.arnProviderCfgsMap[arn]
+	if !ok {
+		return fmt.Errorf("Role %s does not exist", arn)
+	}
+
+	// CVE-2026-33322 / GHSA-5cx5-wh4m-82fh (JWT algorithm confusion):
+	//
+	// MinIO registers the OIDC ClientSecret as an HMAC verification key keyed
+	// by ClientID (see PopulatePublicKey) so that IdPs which sign id_tokens
+	// symmetrically (HS256/384/512) can be supported. However, the verification
+	// key is resolved purely from the attacker-controlled `kid` header and the
+	// accepted algorithms permitted every family unconditionally. An attacker
+	// who learns the ClientSecret could therefore forge a token of the shape
+	// {"alg":"HS256","kid":"<ClientID>"}, sign it with the ClientSecret, and
+	// have it verified against that same secret - even when the IdP actually
+	// signs tokens asymmetrically (RSA/ECDSA). golang-jwt only enforces
+	// ValidMethods, not a binding between the algorithm and the key type, so it
+	// does not stop this on its own.
+	//
+	// Mitigation: HMAC (symmetric) signing is only honoured when the IdP's
+	// discovery document advertises an HMAC id_token signing algorithm. For the
+	// common asymmetric deployments the HS* algorithms are removed from the set
+	// of accepted methods entirely, which prevents the ClientSecret from ever
+	// being used as a token verification key. We additionally bind the token's
+	// algorithm to the resolved key's type inside the keyfunc as defence in
+	// depth.
+	allowHMAC := providerAllowsHMAC(pCfg)
+
 	jp := new(jwtgo.Parser)
 	jp.ValidMethods = []string{
 		"RS256", "RS384", "RS512",
 		"ES256", "ES384", "ES512",
-		"HS256", "HS384", "HS512",
 		"RS3256", "RS3384", "RS3512",
 		"ES3256", "ES3384", "ES3512",
+	}
+	if allowHMAC {
+		jp.ValidMethods = append(jp.ValidMethods, "HS256", "HS384", "HS512")
 	}
 
 	keyFuncCallback := func(jwtToken *jwtgo.Token) (any, error) {
@@ -152,12 +203,32 @@ func (r *Config) Validate(ctx context.Context, arn arn.ARN, token, accessToken, 
 		if pubkey == nil {
 			return nil, fmt.Errorf("No public key found for kid %s", kid)
 		}
-		return pubkey, nil
-	}
 
-	pCfg, ok := r.arnProviderCfgsMap[arn]
-	if !ok {
-		return fmt.Errorf("Role %s does not exist", arn)
+		// CVE-2026-33322 / GHSA-5cx5-wh4m-82fh: bind the token's signing
+		// algorithm to the TYPE of the resolved verification key so that an
+		// asymmetric public key can never be (mis)used as an HMAC secret and a
+		// symmetric secret can never be used to satisfy an asymmetric token.
+		_, isHMACToken := jwtToken.Method.(*jwtgo.SigningMethodHMAC)
+		switch pubkey.(type) {
+		case []byte:
+			// Symmetric (HMAC) secret. Only acceptable when the token uses an
+			// HMAC algorithm AND the provider is configured to permit HMAC.
+			if !isHMACToken {
+				return nil, fmt.Errorf("signing method %q is not allowed for symmetric (HMAC) key kid %s", jwtToken.Method.Alg(), kid)
+			}
+			if !allowHMAC {
+				return nil, fmt.Errorf("HMAC signing is not permitted for provider with client ID %s; the IdP does not advertise an HMAC id_token signing algorithm", pCfg.ClientID)
+			}
+		default:
+			// Asymmetric public key (RSA/ECDSA/...): HMAC signing methods must
+			// never be accepted, otherwise the public key would be treated as
+			// an HMAC secret.
+			if isHMACToken {
+				return nil, fmt.Errorf("HMAC signing method %q is not allowed for asymmetric key kid %s", jwtToken.Method.Alg(), kid)
+			}
+		}
+
+		return pubkey, nil
 	}
 
 	mclaims := jwtgo.MapClaims(claims)

--- a/internal/config/identity/openid/jwt_test.go
+++ b/internal/config/identity/openid/jwt_test.go
@@ -136,7 +136,7 @@ func TestJWTHMACType(t *testing.T) {
 		ClientSecret: "WNGvKVyyNmXq0TraSvjaDN9CtpFgx35IXtGEffMCPR0",
 		// A symmetric (HMAC) IdP advertises an HS* id_token signing algorithm in
 		// its discovery document. Required after the CVE-2026-33322 fix for the
-		// ClientSecret to be honoured as an HMAC verification key.
+		// ClientSecret to be honored as an HMAC verification key.
 		DiscoveryDoc: DiscoveryDoc{
 			IDTokenSigningAlgValuesSupported: []string{"HS256"},
 		},

--- a/internal/config/identity/openid/jwt_test.go
+++ b/internal/config/identity/openid/jwt_test.go
@@ -19,6 +19,8 @@ package openid
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -72,9 +74,9 @@ func TestUpdateClaimsExpiry(t *testing.T) {
 	}
 }
 
-func initJWKSServer() *httptest.Server {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		const jsonkey = `{"keys":
+// jwksRSA is a sample JWKS document containing a single RSA public key with
+// kid "2011-04-29".
+const jwksRSA = `{"keys":
        [
          {"kty":"RSA",
           "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
@@ -83,7 +85,10 @@ func initJWKSServer() *httptest.Server {
           "kid":"2011-04-29"}
        ]
      }`
-		w.Write([]byte(jsonkey))
+
+func initJWKSServer() *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(jwksRSA))
 	}))
 	return server
 }
@@ -129,6 +134,12 @@ func TestJWTHMACType(t *testing.T) {
 	provider := providerCfg{
 		ClientID:     "76b95ae5-33ef-4283-97b7-d2a85dc2d8f4",
 		ClientSecret: "WNGvKVyyNmXq0TraSvjaDN9CtpFgx35IXtGEffMCPR0",
+		// A symmetric (HMAC) IdP advertises an HS* id_token signing algorithm in
+		// its discovery document. Required after the CVE-2026-33322 fix for the
+		// ClientSecret to be honoured as an HMAC verification key.
+		DiscoveryDoc: DiscoveryDoc{
+			IDTokenSigningAlgValuesSupported: []string{"HS256"},
+		},
 	}
 	provider.JWKS.URL = u1
 	cfg := Config{
@@ -149,6 +160,152 @@ func TestJWTHMACType(t *testing.T) {
 	if err = cfg.Validate(t.Context(), DummyRoleARN, token, "", "", claims); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// TestJWTAlgConfusion is a regression test for CVE-2026-33322 /
+// GHSA-5cx5-wh4m-82fh (JWT algorithm confusion in OIDC auth).
+//
+// When an asymmetric IdP signing key is configured (via JWKS), an attacker who
+// knows the ClientSecret must NOT be able to forge a token of the shape
+// {"alg":"HS256","kid":"<ClientID>"} signed with the ClientSecret and have it
+// accepted. We also assert that a legitimate RSA-signed token continues to
+// validate, and that a genuine symmetric (HMAC) setup still works.
+func TestJWTAlgConfusion(t *testing.T) {
+	server := initJWKSServer() // serves an RSA key with kid "2011-04-29"
+	defer server.Close()
+
+	u1, err := xnet.ParseHTTPURL(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const clientID = "76b95ae5-33ef-4283-97b7-d2a85dc2d8f4"
+	const clientSecret = "WNGvKVyyNmXq0TraSvjaDN9CtpFgx35IXtGEffMCPR0"
+
+	// newCfg builds a Config for a provider. algs is what the IdP's discovery
+	// document advertises as its id_token signing algorithms. The ClientSecret
+	// is registered as an HMAC key under the ClientID exactly like
+	// PopulatePublicKey does, and the asymmetric JWKS key (kid "2011-04-29") is
+	// loaded, mirroring a real deployment where both live in the same key map.
+	newCfg := func(algs ...string) (Config, *rsa.PrivateKey) {
+		pubKeys := publicKeys{
+			RWMutex: &sync.RWMutex{},
+			pkMap:   map[string]any{},
+		}
+		pubKeys.add(clientID, []byte(clientSecret))
+		if err := pubKeys.parseAndAdd(bytes.NewBufferString(jwksRSA)); err != nil {
+			t.Fatalf("Error loading pubkeys: %v", err)
+		}
+		// Add a fresh RSA key we control under a known kid so we can mint
+		// genuinely IdP-signed RS256 tokens.
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pubKeys.add("rs-test-kid", &privKey.PublicKey)
+
+		provider := providerCfg{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			DiscoveryDoc: DiscoveryDoc{
+				IDTokenSigningAlgValuesSupported: algs,
+			},
+		}
+		provider.JWKS.URL = u1
+		return Config{
+			Enabled: true,
+			pubKeys: pubKeys,
+			arnProviderCfgsMap: map[arn.ARN]*providerCfg{
+				DummyRoleARN: &provider,
+			},
+			ProviderCfgs: map[string]*providerCfg{
+				"1": &provider,
+			},
+			closeRespFn: func(rc io.ReadCloser) { rc.Close() },
+		}, privKey
+	}
+
+	// (a) THE EXPLOIT. Asymmetric IdP (advertises only RS256). Attacker who
+	// knows the ClientSecret forges {"alg":"HS256","kid":"<ClientID>"} and signs
+	// it with the ClientSecret. Pre-fix this verified against the HMAC key
+	// registered under the ClientID and was accepted. It MUST now be rejected.
+	t.Run("exploit-hs256-kid-clientID", func(t *testing.T) {
+		cfg, _ := newCfg("RS256")
+		tok := jwtgo.New(jwtgo.SigningMethodHS256)
+		tok.Header["kid"] = clientID
+		tok.Claims = jwtgo.MapClaims{
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"aud": clientID,
+		}
+		signed, err := tok.SignedString([]byte(clientSecret))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var claims jwtgo.MapClaims
+		if err := cfg.Validate(t.Context(), DummyRoleARN, signed, "", "", claims); err == nil {
+			t.Fatal("SECURITY: forged HS256 token (kid=ClientID, signed with ClientSecret) was ACCEPTED against an asymmetric IdP")
+		}
+	})
+
+	// (a2) Variant: attacker targets the asymmetric JWKS kid with an HS256 alg.
+	// Must also be rejected (key-type/alg binding in the keyfunc).
+	t.Run("exploit-hs256-kid-asymmetric", func(t *testing.T) {
+		cfg, _ := newCfg("RS256")
+		tok := jwtgo.New(jwtgo.SigningMethodHS256)
+		tok.Header["kid"] = "2011-04-29"
+		tok.Claims = jwtgo.MapClaims{
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"aud": clientID,
+		}
+		signed, err := tok.SignedString([]byte(clientSecret))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var claims jwtgo.MapClaims
+		if err := cfg.Validate(t.Context(), DummyRoleARN, signed, "", "", claims); err == nil {
+			t.Fatal("SECURITY: HS256 token with asymmetric kid was accepted")
+		}
+	})
+
+	// (b) Legitimate RSA-signed token (the normal path for an asymmetric IdP)
+	// still validates.
+	t.Run("legitimate-rs256", func(t *testing.T) {
+		cfg, privKey := newCfg("RS256")
+		tok := jwtgo.New(jwtgo.SigningMethodRS256)
+		tok.Header["kid"] = "rs-test-kid"
+		tok.Claims = jwtgo.MapClaims{
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"aud": clientID,
+		}
+		signed, err := tok.SignedString(privKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var claims jwtgo.MapClaims
+		if err := cfg.Validate(t.Context(), DummyRoleARN, signed, "", "", claims); err != nil {
+			t.Fatalf("legitimate RS256 token rejected: %v", err)
+		}
+	})
+
+	// (c) Genuine symmetric (HMAC) deployment: the IdP advertises HS256, so an
+	// HS256 token whose kid resolves to the HMAC secret must still validate.
+	t.Run("legitimate-hs256", func(t *testing.T) {
+		cfg, _ := newCfg("HS256")
+		tok := jwtgo.New(jwtgo.SigningMethodHS256)
+		tok.Header["kid"] = clientID
+		tok.Claims = jwtgo.MapClaims{
+			"exp": time.Now().Add(time.Hour).Unix(),
+			"aud": clientID,
+		}
+		signed, err := tok.SignedString([]byte(clientSecret))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var claims jwtgo.MapClaims
+		if err := cfg.Validate(t.Context(), DummyRoleARN, signed, "", "", claims); err != nil {
+			t.Fatalf("legitimate HS256 token rejected: %v", err)
+		}
+	})
 }
 
 func TestJWT(t *testing.T) {


### PR DESCRIPTION
## Summary
Patches **CVE-2026-33322** ([GHSA-5cx5-wh4m-82fh](https://github.com/minio/minio/security/advisories/GHSA-5cx5-wh4m-82fh)) — Critical JWT **algorithm-confusion** in OIDC authentication. An attacker who knows the OIDC `ClientSecret` can forge an ID token and obtain S3 credentials with any policy (incl. `consoleAdmin`). No upstream OSS patch exists (fix is AIStor-only), so this is an EmeritOSS best-effort source patch.

## The bug
`internal/config/identity/openid/jwt.go` registers the `ClientSecret` as an HMAC verification key keyed by `ClientID`, and `ValidMethods` permits `HS*` alongside `RS*/ES*` unconditionally. The keyfunc resolves the key purely by the token's attacker-controlled `kid` with no alg/key-type binding. So a forged `{"alg":"HS256","kid":"<ClientID>"}` token signed with the ClientSecret verifies successfully.

⚠️ **Important subtlety:** a keyfunc-only alg/key-type binding does **not** close the hole — for the `kid=ClientID` exploit the resolved key genuinely *is* the HMAC secret, so a type check passes it. This was proven with an exploit test before settling on the fix below.

## The fix
Two layers:
1. **Decisive:** `HS*` is accepted only when the IdP's OIDC discovery document advertises an HMAC `id_token_signing_alg_values_supported`. Asymmetric IdPs drop `HS*` from `ValidMethods` entirely, so the ClientSecret can never be used as a token verification key. Conservative default (no advertised alg → HMAC disallowed).
2. **Defence in depth:** keyfunc binds the token signing method to the resolved key TYPE.

Both change sites carry `CVE-2026-33322` comments.

## Scope assessment
Within EmeritOSS best-effort source-CVE policy: contained to one file + tests, no API change. **Auth-critical — requires ProdSec PSIRT review before merge.**

⚠️ **Behaviour change to review:** a genuinely symmetric IdP that omits `id_token_signing_alg_values_supported` will now have HMAC withheld (fails safe / deny). Affects only HMAC-OIDC setups; asymmetric unaffected.

## Test plan
- [ ] CI green
- Added `TestJWTAlgConfusion`: forged HS256+ClientSecret token against an RS256 IdP is **rejected** (confirmed FAILS pre-fix); legitimate RS256 and legitimate HMAC setups still validate.
- `go build ./internal/config/identity/openid/...` + `go test ./internal/config/identity/openid/...` pass locally.

Refs: GHSA-5cx5-wh4m-82fh / CVE-2026-33322 · Tracking: chainguard-dev/customer-issues#3598 · Linear OS-2158