### PR TITLE
fix: require signature verification in Snowball extract handler (CVE-2026-40344)

### DIFF
--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -2247,7 +2247,7 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 	// if Content-Length is unknown/missing, deny the request
 	size := r.ContentLength
 	rAuthType := getRequestAuthType(r)
-	if rAuthType == authTypeStreamingSigned || rAuthType == authTypeStreamingSignedTrailer {
+	if rAuthType == authTypeStreamingSigned || rAuthType == authTypeStreamingSignedTrailer || rAuthType == authTypeStreamingUnsignedTrailer {
 		if sizeStr, ok := r.Header[xhttp.AmzDecodedContentLength]; ok {
 			if sizeStr[0] == "" {
 				writeErrorResponse(ctx, w, errorCodes.ToAPIErr(ErrMissingContentLength), r.URL)
@@ -2297,6 +2297,28 @@ func (api objectAPIHandlers) PutObjectExtractHandler(w http.ResponseWriter, r *h
 	case authTypeStreamingSigned, authTypeStreamingSignedTrailer:
 		// Initialize stream signature verifier.
 		reader, s3Err = newSignV4ChunkedReader(r, rAuthType == authTypeStreamingSignedTrailer)
+		if s3Err != ErrNone {
+			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
+			return
+		}
+	case authTypeStreamingUnsignedTrailer:
+		// CVE-2026-40344 (Vuln 1): the streaming-unsigned-trailer auth type was
+		// added upstream (PR #16484) to PutObjectHandler and PutObjectPartHandler
+		// but never wired into this Snowball auto-extract handler. Without this
+		// case the request fell through the switch with ZERO signature
+		// verification (isPutActionAllowed only checks the access key + IAM
+		// policy, not the cryptographic signature), allowing an attacker holding
+		// a valid access key but a fabricated Authorization signature to extract
+		// an arbitrary tar payload into the bucket.
+		//
+		// Mirror the protected handlers: wrap the body in the unsigned chunked
+		// reader, which verifies the request signature when credentials are
+		// present. Require signature verification whenever credentials are
+		// supplied via either the Authorization header or the X-Amz-Credential
+		// query parameter; otherwise an attacker could pass credentials through
+		// the query string and bypass signing entirely (CVE-2026-41145, Vuln 2).
+		hasCreds := r.Header.Get(xhttp.Authorization) != "" || r.Form.Get(xhttp.AmzCredential) != ""
+		reader, s3Err = newUnsignedV4ChunkedReader(r, true, hasCreds)
 		if s3Err != ErrNone {
 			writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Err), r.URL)
 			return

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -18,6 +18,7 @@
 package cmd
 
 import (
+	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/xml"
@@ -129,6 +130,7 @@ func runAllTests(suite *TestSuiteCommon, c *check) {
 	suite.TestBucketSQSNotificationAMQP(c)
 	suite.TestUnsignedCVE(c)
 	suite.TestCVE202641145(c)
+	suite.TestCVE202640344SnowballExtract(c)
 	suite.TearDownSuite(c)
 }
 
@@ -483,6 +485,113 @@ func (s *TestSuiteCommon) TestCVE202641145(c *check) {
 	response, err = s.client.Do(legitReq)
 	c.Assert(err, nil)
 	c.Assert(response.StatusCode, http.StatusOK)
+}
+
+// TestCVE202640344SnowballExtract is a regression test for CVE-2026-40344
+// (Vuln 1): missing signature verification in the Snowball auto-extract handler
+// (PutObjectExtractHandler).
+//
+// When the STREAMING-UNSIGNED-PAYLOAD-TRAILER auth type was added upstream
+// (PR #16484) it was wired into PutObjectHandler and PutObjectPartHandler but
+// never into PutObjectExtractHandler. Its switch had no case for
+// authTypeStreamingUnsignedTrailer (and no default), so a request with that
+// content-sha256, the Snowball auto-extract header, and a valid access key but
+// a *fabricated* Authorization signature fell through with ZERO signature
+// verification — isPutActionAllowed only checks the access key + IAM policy,
+// not the cryptographic signature — and the tar payload was extracted into the
+// bucket.
+//
+// The fix adds the missing case so the body is wrapped in
+// newUnsignedV4ChunkedReader, which verifies the signature when credentials are
+// present (and via the hasCreds gate also defends against the CVE-2026-41145
+// query-string bypass).
+func (s *TestSuiteCommon) TestCVE202640344SnowballExtract(c *check) {
+	c.Helper()
+
+	bucketName := getRandomBucketName()
+	request, err := newTestSignedRequest(http.MethodPut, getMakeBucketURL(s.endPoint, bucketName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, nil)
+	response, err := s.client.Do(request)
+	c.Assert(err, nil)
+	c.Assert(response.StatusCode, http.StatusOK)
+
+	// Build a small tar payload containing a single file. This is the
+	// "decoded" content that the extract handler would unpack into the bucket.
+	fileName := "extracted.txt"
+	fileData := []byte("snowball-payload")
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	c.Assert(tw.WriteHeader(&tar.Header{
+		Name: fileName,
+		Mode: 0o600,
+		Size: int64(len(fileData)),
+	}), nil)
+	_, err = tw.Write(fileData)
+	c.Assert(err, nil)
+	c.Assert(tw.Close(), nil)
+	tarBytes := tarBuf.Bytes()
+
+	// aws-chunked encoding of the tar payload as a single chunk.
+	chunkedBody := fmt.Sprintf("%x\r\n%s\r\n0\r\n", len(tarBytes), tarBytes)
+
+	// --- Attack case: STREAMING-UNSIGNED-PAYLOAD-TRAILER snowball extract with a
+	// fabricated Authorization signature. Before the fix this fell through the
+	// switch unverified and the tar was extracted; now it must be rejected.
+	attackReq, err := http.NewRequest(http.MethodPut,
+		getPutObjectURL(s.endPoint, bucketName, "attack.tar"), nil)
+	c.Assert(err, nil)
+	attackReq.Body = io.NopCloser(strings.NewReader(chunkedBody))
+	attackReq.ContentLength = int64(len(chunkedBody))
+	attackReq.Header.Set("x-amz-content-sha256", unsignedPayloadTrailer)
+	attackReq.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(tarBytes)))
+	attackReq.Header.Set("Content-Encoding", "aws-chunked")
+	attackReq.Header.Set(xhttp.AmzSnowballExtract, "true")
+	// Sign first to obtain a well-formed credential scope/date, then clobber the
+	// signature portion of the Authorization header so the access key is valid
+	// but the signature is fabricated.
+	err = signRequestV4(attackReq, s.accessKey, s.secretKey)
+	c.Assert(err, nil)
+	auth := attackReq.Header.Get("Authorization")
+	c.Assert(strings.Contains(auth, "Signature="), true)
+	attackReq.Header.Set("Authorization",
+		regexp.MustCompile(`Signature=[0-9a-f]+`).ReplaceAllString(auth, "Signature="+strings.Repeat("0", 64)))
+
+	response, err = s.client.Do(attackReq)
+	c.Assert(err, nil)
+	if response.StatusCode == http.StatusOK {
+		c.Fatal("CVE-2026-40344: Snowball extract PUT with a fabricated signature was accepted; signature verification is missing in PutObjectExtractHandler")
+	}
+
+	// --- Legitimate case: same streaming content type and snowball header with a
+	// proper signature. Ensures the fix does not break valid extract uploads.
+	legitReq, err := http.NewRequest(http.MethodPut,
+		getPutObjectURL(s.endPoint, bucketName, "legit.tar"), nil)
+	c.Assert(err, nil)
+	legitReq.Body = io.NopCloser(strings.NewReader(chunkedBody))
+	legitReq.ContentLength = int64(len(chunkedBody))
+	legitReq.Header.Set("x-amz-content-sha256", unsignedPayloadTrailer)
+	legitReq.Header.Set("X-Amz-Decoded-Content-Length", fmt.Sprintf("%d", len(tarBytes)))
+	legitReq.Header.Set("Content-Encoding", "aws-chunked")
+	legitReq.Header.Set(xhttp.AmzSnowballExtract, "true")
+	err = signRequestV4(legitReq, s.accessKey, s.secretKey)
+	c.Assert(err, nil)
+
+	response, err = s.client.Do(legitReq)
+	c.Assert(err, nil)
+	c.Assert(response.StatusCode, http.StatusOK)
+
+	// The extracted file should now exist as its own object in the bucket.
+	getReq, err := newTestSignedRequest(http.MethodGet,
+		getGetObjectURL(s.endPoint, bucketName, fileName),
+		0, nil, s.accessKey, s.secretKey, s.signer)
+	c.Assert(err, nil)
+	response, err = s.client.Do(getReq)
+	c.Assert(err, nil)
+	c.Assert(response.StatusCode, http.StatusOK)
+	got, err := io.ReadAll(response.Body)
+	c.Assert(err, nil)
+	c.Assert(string(got), string(fileData))
 }
 
 func (s *TestSuiteCommon) TestBucketSQSNotificationAMQP(c *check) {


### PR DESCRIPTION
## Summary
Patches **Vulnerability 1** of **CVE-2026-40344** ([GHSA-9c4q-hq6p-c237](https://github.com/minio/minio/security/advisories/GHSA-9c4q-hq6p-c237)) — High, missing signature verification in the Snowball auto-extract handler. No upstream OSS patch (AIStor-only); EmeritOSS best-effort source patch.

## The bug
When `authTypeStreamingUnsignedTrailer` support was added upstream (PR #16484), it was wired into `PutObjectHandler` and `PutObjectPartHandler` but **never** into `PutObjectExtractHandler`. That handler's `switch rAuthType` has no `authTypeStreamingUnsignedTrailer` case and no `default`, so a Snowball extract PUT with `X-Amz-Content-Sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`, `X-Amz-Meta-Snowball-Auto-Extract: true`, a valid access key and a **fabricated signature** falls through with zero signature verification and the tar is extracted into the bucket. `isPutActionAllowed` only checks the access key + IAM, not the signature.

(Vulnerability 2 of this CVE — query-string credential bypass — was already fixed in `b94db7d78`; this PR is scoped to Vuln 1.)

## The fix
Adds the missing `case authTypeStreamingUnsignedTrailer:` to `PutObjectExtractHandler`, wrapping the body in `newUnsignedV4ChunkedReader(r, true, hasCreds)` with the post-CVE-2026-41145 `hasCreds := Authorization || X-Amz-Credential` gate — so unsigned-trailer requests get signature verification and Vuln 2 is **not** reintroduced. Also extends the `X-Amz-Decoded-Content-Length` size-decode guard to cover `authTypeStreamingUnsignedTrailer` (otherwise the decoded read size would be wrong for aws-chunked unsigned-trailer bodies), matching `PutObjectHandler`.

Change site carries a `CVE-2026-40344` comment.

## Scope assessment
Within EmeritOSS best-effort policy: small, contained, mirrors the already-patched sibling handlers, no API change. Should get ProdSec PSIRT review before merge.

## Test plan
- [ ] CI green
- Added `TestCVE202640344SnowballExtract` (end-to-end, runs across ErasureSD/Erasure/ErasureSet): attack request with clobbered signature is **rejected**; legitimate signed request returns 200 and the extracted object reads back correctly. Negative control (fix removed) confirmed the test FAILS, so it genuinely detects the missing verification.
- `go build ./cmd/...` + targeted `go test ./cmd/...` pass locally.

Refs: GHSA-9c4q-hq6p-c237 / CVE-2026-40344 · Tracking: chainguard-dev/customer-issues#3598 · Linear OS-2158