### PR TITLE
fix(api): forward Flush and Hijack in trackingResponseWriter

### DIFF
--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -18,10 +18,12 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"encoding/xml"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"path"
@@ -1062,4 +1064,23 @@ func (w *trackingResponseWriter) Write(b []byte) (int, error) {
 
 func (w *trackingResponseWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
+}
+
+// Flush forwards a flush to the wrapped ResponseWriter. Without this the
+// wrapper does not satisfy http.Flusher, which breaks the flush chain for
+// streaming responses such as the bucket notification listener, leaving
+// streamed bytes buffered and never sent to the client.
+func (w *trackingResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards a hijack to the wrapped ResponseWriter so that handlers
+// relying on connection hijacking keep working through the wrapper.
+func (w *trackingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("hijack not supported by underlying ResponseWriter")
 }

--- a/cmd/api-response_test.go
+++ b/cmd/api-response_test.go
@@ -18,7 +18,9 @@
 package cmd
 
 import (
+	"bufio"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -130,7 +132,8 @@ func TestGetURLScheme(t *testing.T) {
 func TestTrackingResponseWriter(t *testing.T) {
 	rw := httptest.NewRecorder()
 	trw := &trackingResponseWriter{ResponseWriter: rw}
-	trw.WriteHeader(123)
+	// Use a 2xx status: Go 1.26 httptest rejects a body write after a 1xx code.
+	trw.WriteHeader(234)
 	if !trw.headerWritten {
 		t.Fatal("headerWritten was not set by WriteHeader call")
 	}
@@ -142,7 +145,7 @@ func TestTrackingResponseWriter(t *testing.T) {
 
 	// Check that WriteHeader and Write were called on the underlying response writer
 	resp := rw.Result()
-	if resp.StatusCode != 123 {
+	if resp.StatusCode != 234 {
 		t.Fatalf("unexpected status: %v", resp.StatusCode)
 	}
 	body, err := io.ReadAll(resp.Body)
@@ -156,6 +159,54 @@ func TestTrackingResponseWriter(t *testing.T) {
 	// Check that Unwrap works
 	if trw.Unwrap() != rw {
 		t.Fatalf("Unwrap returned wrong result: %v", trw.Unwrap())
+	}
+}
+
+// hijackableResponseWriter is a ResponseWriter that supports hijacking, used to
+// verify that trackingResponseWriter forwards Hijack to the wrapped writer.
+type hijackableResponseWriter struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *hijackableResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	return nil, nil, nil
+}
+
+// TestTrackingResponseWriterFlushHijack guards against a regression where
+// trackingResponseWriter did not forward Flush or Hijack. That broke the flush
+// chain for streaming responses such as ListenBucketNotification, whose chunked
+// event-stream never reached the client.
+func TestTrackingResponseWriterFlushHijack(t *testing.T) {
+	// The wrapper must satisfy both interfaces so it does not silently disable
+	// flushing or hijacking when it wraps a writer that supports them.
+	var _ http.Flusher = (*trackingResponseWriter)(nil)
+	var _ http.Hijacker = (*trackingResponseWriter)(nil)
+
+	// Flush must forward to the wrapped writer.
+	rw := httptest.NewRecorder()
+	trw := &trackingResponseWriter{ResponseWriter: rw}
+	trw.Flush()
+	if !rw.Flushed {
+		t.Fatal("Flush was not forwarded to the underlying ResponseWriter")
+	}
+
+	// Hijack must forward when the wrapped writer supports hijacking.
+	hj := &hijackableResponseWriter{ResponseRecorder: httptest.NewRecorder()}
+	trw = &trackingResponseWriter{ResponseWriter: hj}
+	if _, _, err := trw.Hijack(); err != nil {
+		t.Fatalf("Hijack unexpectedly failed: %v", err)
+	}
+	if !hj.hijacked {
+		t.Fatal("Hijack was not forwarded to the underlying ResponseWriter")
+	}
+
+	// Hijack must return an error, not panic, when the wrapped writer does not
+	// support hijacking.
+	trw = &trackingResponseWriter{ResponseWriter: httptest.NewRecorder()}
+	if _, _, err := trw.Hijack(); err == nil {
+		t.Fatal("expected an error hijacking a non-hijackable ResponseWriter")
 	}
 }
 


### PR DESCRIPTION
## Problem

`ListenBucketNotification` never streams to clients on recent builds. A client
opens the listen stream, receives no HTTP response headers, keepalives, or
events, and eventually times out awaiting headers. Other streaming endpoints
such as `mc watch` and `mc admin trace` are affected the same way. An older
build streams notifications reliably, so this is a regression.

## Root cause

Commit 52eee5a2f ("fix(api): Don't send multiple responses for one request",
#21651) wraps every S3 API response in a `trackingResponseWriter`. It implements
`WriteHeader`, `Write`, and `Unwrap`, but not `Flush` or `Hijack`, so it does
not satisfy `http.Flusher`.

The listen handler returns a chunked `text/event-stream` response and is wrapped
by the gzip response middleware, so its writes must flush through
`trackingResponseWriter` to reach the socket. With `Flush` missing, the flush
chain breaks: the initial headers and every event stay buffered and never reach
the client.

## Fix

Forward `Flush` and `Hijack` from `trackingResponseWriter` to the wrapped
`ResponseWriter`.

## Testing

- New `TestTrackingResponseWriterFlushHijack` asserts the wrapper satisfies
  `http.Flusher` and `http.Hijacker` and forwards both.
- Verified end to end with a minio-go reproducer and a raw HTTP capture:
  notifications are delivered again at millisecond latency, matching the older
  build. Reproducer: https://github.com/mosabua/minio-listen-repro
- `TestTrackingResponseWriter` switched to a 2xx status, since Go 1.26 httptest
  rejects a body write after a 1xx status code.

## How this was found

Surfaced while bumping the MinIO test container in Trino,
https://github.com/trinodb/trino/pull/29092, where the Delta Lake bucket
notification tests stopped receiving events.